### PR TITLE
Feat/bray-curtis

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.1.3
+current_version = 1.1.4
 commit = False
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[a-z]+)(?P<dev>\d+))?

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "distances"
-version = "1.1.3"
+version = "1.1.4"
 authors = [
     "Najib Ishaq <najib_ishaq@zoho.com>",
     "Noah Daniels <noah_daniels@uri.edu>",

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ assert!((distance - (27.0_f32).sqrt()).abs() < 1e-6);
   - [x] `hamming`
   - [x] `canberra`
     - [Canberra Distance](https://en.wikipedia.org/wiki/Canberra_distance)
-  - [ ] `bray_curtis`
+  - [x] `bray_curtis`
     - [Bray-Curtis Distance](https://en.wikipedia.org/wiki/Bray%E2%80%93Curtis_dissimilarity)
   - [ ] `pearson`
     - `1.0 - r` where `r` is the [Pearson Correlation Coefficient](https://en.wikipedia.org/wiki/Pearson_correlation_coefficient)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Distances (v1.1.3)
+# Distances (v1.1.4)
 
 Fast and generic distance functions for high-dimensional data.
 
@@ -7,7 +7,7 @@ Fast and generic distance functions for high-dimensional data.
 Add this to your project:
 
 ```shell
-> cargo add distances@1.1.3
+> cargo add distances@1.1.4
 ```
 
 Use it in your project:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,4 +28,4 @@ pub mod strings;
 pub mod vectors;
 
 /// The version of the crate.
-pub const VERSION: &str = "1.1.3";
+pub const VERSION: &str = "1.1.4";

--- a/src/vectors/angular.rs
+++ b/src/vectors/angular.rs
@@ -1,5 +1,7 @@
 //! Angular distances between vectors.
 
+use core::cmp::min;
+
 use crate::{
     number::{Float, Int, UInt},
     Number,
@@ -150,9 +152,6 @@ pub fn canberra<T: Number, U: Float>(x: &[T], y: &[T]) -> U {
 /// * `x`: A slice of numbers.
 /// * `y`: A slice of numbers.
 ///
-/// The function won't panic if given vectors with floating point entries or
-/// negative entries, but Bray-Curtis dissimilarity is intended for use
-/// with vectors of non-negative integers.
 ///
 /// # Examples
 /// ```
@@ -169,13 +168,13 @@ pub fn canberra<T: Number, U: Float>(x: &[T], y: &[T]) -> U {
 /// # References
 ///
 /// * [Bray-Curtis dissimilarity](https://en.wikipedia.org/wiki/Bray%E2%80%93Curtis_dissimilarity)
-pub fn bray_curtis<T: Number, U: Float>(x: &[T], y: &[T]) -> U {
-    let [sum_x, sum_y, sum_min] =
-        x.iter()
-            .zip(y.iter())
-            .fold([T::zero(); 3], |[sum_x, sum_y, sum_min], (&a, &b)| {
-                [a + sum_x, b + sum_y, if a > b { b } else { a } + sum_min]
-            });
+pub fn bray_curtis<T: UInt, U: Float>(x: &[T], y: &[T]) -> U {
+    let [sum_x, sum_y, sum_min] = x
+        .iter()
+        .zip(y.iter())
+        .fold([T::zero(); 3], |[sum_a, sum_b, sum_min], (&a, &b)| {
+            [a + sum_a, b + sum_b, min(a, b) + sum_min]
+        });
 
     let [sum_x, sum_y, sum_min] = [U::from(sum_x), U::from(sum_y), U::from(sum_min)];
 

--- a/src/vectors/angular.rs
+++ b/src/vectors/angular.rs
@@ -176,16 +176,14 @@ pub fn bray_curtis<T: UInt, U: Float>(x: &[T], y: &[T]) -> U {
             [a + sum_a, b + sum_b, min(a, b) + sum_min]
         });
 
-    let [sum_x, sum_y, sum_min] = [U::from(sum_x), U::from(sum_y), U::from(sum_min)];
-
-    if sum_x < U::epsilon() || sum_y < U::epsilon() || sum_min < U::epsilon() {
+    if sum_x == T::zero() || sum_y == T::zero() || sum_min == T::zero() {
         U::one()
     } else {
-        let d = U::one() - U::from(2) * sum_min / (sum_x + sum_y);
-        if d < U::epsilon() {
+        let (numerator, denominator) = (sum_min + sum_min, sum_x + sum_y);
+        if denominator <= numerator {
             U::zero()
         } else {
-            d
+            U::one() - U::from(numerator) / U::from(denominator)
         }
     }
 }

--- a/src/vectors/lp_norms.rs
+++ b/src/vectors/lp_norms.rs
@@ -132,7 +132,7 @@ pub fn l3_norm<T: Number, U: Float>(x: &[T], y: &[T]) -> U {
 /// L4-norm between two vectors.
 ///
 /// The L4-norm is defined as the fourth root of the sum of the fourth powers of
-/// the absolute differences between the corresponding elements of the two
+/// the absolute differences between the corresponding elements of the two vectors.
 ///
 /// See the [`crate::vectors`] module documentation for information on this
 /// function's potentially unexpected behaviors
@@ -229,6 +229,7 @@ pub fn minkowski_p<T: Number, U: Float>(p: i32) -> impl Fn(&[T], &[T]) -> U {
 ///
 /// The Lp-norm is defined as the pth root of the sum of the pth powers of
 /// the absolute differences between the corresponding elements of the two
+/// vectors.
 ///
 /// See the [`crate::vectors`] module documentation for information on this
 /// function's potentially unexpected behaviors

--- a/src/vectors/mod.rs
+++ b/src/vectors/mod.rs
@@ -10,7 +10,7 @@ mod angular;
 mod lp_norms;
 pub(crate) mod utils;
 
-pub use angular::{canberra, cosine, hamming};
+pub use angular::{bray_curtis, canberra, cosine, hamming};
 pub use lp_norms::{
     chebyshev, euclidean, euclidean_sq, l3_norm, l4_norm, manhattan, minkowski, minkowski_p,
 };


### PR DESCRIPTION
Added Bray-Curtis dissimilarity. In addition to the test shown, I tested this on the edge case where the vectors are identical (i.e. dissimilarity is 0.) and also where they have absolutely no overlap (i.e. dissimilarity is 1.) but did not put those tests under the "examples" part of the documentation to avoid making it too cumbersome. 