### PR TITLE
added dot product distance

### DIFF
--- a/src/vectors/angular.rs
+++ b/src/vectors/angular.rs
@@ -187,3 +187,84 @@ pub fn bray_curtis<T: UInt, U: Float>(x: &[T], y: &[T]) -> U {
         }
     }
 }
+
+/// Computes the dot product between two vectors.
+///
+/// The dot product is defined as the sum of the products of the
+/// corresponding entries of the two vectors.
+///
+/// # Arguments
+///
+/// * `x`: A slice of numbers.
+/// * `y`: A slice of numbers.
+///
+/// # Examples
+///
+/// ```
+/// use distances::vectors::dot_product;
+///
+/// let x: Vec<f32> = vec![1.0, 5.0, 4.0];
+/// let y: Vec<f32> = vec![2.5, 3.0, 0.5];
+///
+/// let distance: f32 = dot_product(&x, &y);
+///
+/// assert!((distance - 19.5).abs() < f32::EPSILON);
+/// ```
+///
+/// # References
+///
+/// * [Dot product](https://en.wikipedia.org/wiki/Dot_product)
+pub fn dot_product<T: Number, U: Float>(x: &[T], y: &[T]) -> U {
+    let dot_product: T = x.iter().zip(y.iter()).map(|(&a, &b)| a * b).sum();
+
+    let dot_product: U = U::from(dot_product);
+
+    if dot_product < U::epsilon() {
+        U::zero()
+    } else {
+        dot_product
+    }
+}
+
+/// Computes a distance between two vectors using their dot product.
+/// Vectors with greater dot products are considered more similar,
+/// and hence have a smaller distance.
+///
+/// The dot product is defined as the sum of the products of the
+/// corresponding entries of the two vectors.
+///
+/// Thia function is not stable.
+///
+/// See the [`crate::vectors`] module documentation for information on this
+/// function's potentially unexpected behaviors
+///
+/// # Arguments
+///
+/// * `x`: A slice of numbers.
+/// * `y`: A slice of numbers.
+///
+/// # Examples
+///
+/// ```
+/// use distances::vectors::dot_product_distance;
+///
+/// let x: Vec<f32> = vec![1.0, 5.0, 4.0];
+/// let y: Vec<f32> = vec![2.5, 3.0, 0.5];
+///
+/// let distance: f32 = dot_product_distance(&x, &y);
+///
+/// assert!((distance - 0.05128205128).abs() < f32::EPSILON);
+/// ```
+///
+/// # References
+///
+/// * [Dot product](https://en.wikipedia.org/wiki/Dot_product)
+pub fn dot_product_distance<T: Number, U: Float>(x: &[T], y: &[T]) -> U {
+    let dot_product: U = dot_product(x, y);
+
+    if dot_product < U::epsilon() {
+        dot_product
+    } else {
+        U::one() / dot_product
+    }
+}

--- a/src/vectors/mod.rs
+++ b/src/vectors/mod.rs
@@ -10,7 +10,7 @@ mod angular;
 mod lp_norms;
 pub(crate) mod utils;
 
-pub use angular::{bray_curtis, canberra, cosine, hamming};
+pub use angular::{bray_curtis, canberra, cosine, dot_product_distance, hamming};
 pub use lp_norms::{
     chebyshev, euclidean, euclidean_sq, l3_norm, l4_norm, manhattan, minkowski, minkowski_p,
 };


### PR DESCRIPTION
- Added dot product function 
- Added "dot_product_distance" function for creating a distance function based on the dot product (right now, this is just the reciprocal of the dot product) 

N.B. Because we haven't reached a consensus about how to deal with distance in the case of 0 dot product and because we are likely to change this function, I just have dot_product_distance return the dot product in this case. It really should return something near infinity. I marked that the function isn't stable. 

Also N.B., I was originally going to call the functions inner_product and inner_product_distance to be consistent with the language in the competition, but I changed the phrasing to dot product because the vectors are finite dimensional and real-valued, and so it is just a dot product. I thought it would be better to reserve the name inner_product for a more general class of inner_product functions (i.e., for anything that satisfies the four criteria for an inner product, even if it is not the same as the dot product). 