### PR TITLE
SIMD cosine and 512-bit

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.6.0-dev0
+current_version = 1.4.1
 commit = False
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[a-z]+)(?P<dev>\d+))?

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.4.1
+current_version = 1.5.0
 commit = False
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[a-z]+)(?P<dev>\d+))?

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.4.1
+current_version = 1.6.0-dev0
 commit = False
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[a-z]+)(?P<dev>\d+))?

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "distances"
-version = "1.4.1"
+version = "1.5.0"
 authors = [
     "Najib Ishaq <najib_ishaq@zoho.com>",
     "Noah Daniels <noah_daniels@uri.edu>",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ publish = true
 [dev-dependencies]
 criterion = { version = "0.5.1", features = ["html_reports"] }
 symagen = { version = "0.1.1", path = "../SyMaGen" }
+test-case = "3.2.1"
 
 [[bench]]
 name = "inv-sqrt"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "distances"
-version = "1.6.0-dev0"
+version = "1.4.1"
 authors = [
     "Najib Ishaq <najib_ishaq@zoho.com>",
     "Noah Daniels <noah_daniels@uri.edu>",
@@ -21,8 +21,7 @@ publish = true
 
 [dev-dependencies]
 criterion = { version = "0.5.1", features = ["html_reports"] }
-# symagen = { path = "../SyMaGen" }
-symagen = "0.1.1"
+symagen = { version = "0.1.1", path = "../SyMaGen" }
 
 [[bench]]
 name = "inv-sqrt"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "distances"
-version = "1.4.1"
+version = "1.6.0-dev0"
 authors = [
     "Najib Ishaq <najib_ishaq@zoho.com>",
     "Noah Daniels <noah_daniels@uri.edu>",

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Distances (v1.4.1)
+# Distances (v1.5.0)
 
 Fast and generic distance functions for high-dimensional data.
 
@@ -7,7 +7,7 @@ Fast and generic distance functions for high-dimensional data.
 Add this to your project:
 
 ```shell
-> cargo add distances@1.4.1
+> cargo add distances@1.5.0
 ```
 
 Use it in your project:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Distances (v1.6.0-dev0)
+# Distances (v1.4.1)
 
 Fast and generic distance functions for high-dimensional data.
 
@@ -7,7 +7,7 @@ Fast and generic distance functions for high-dimensional data.
 Add this to your project:
 
 ```shell
-> cargo add distances@1.6.0-dev0
+> cargo add distances@1.4.1
 ```
 
 Use it in your project:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Distances (v1.4.1)
+# Distances (v1.6.0-dev0)
 
 Fast and generic distance functions for high-dimensional data.
 
@@ -7,7 +7,7 @@ Fast and generic distance functions for high-dimensional data.
 Add this to your project:
 
 ```shell
-> cargo add distances@1.4.1
+> cargo add distances@1.6.0-dev0
 ```
 
 Use it in your project:

--- a/benches/simd-cosine.rs
+++ b/benches/simd-cosine.rs
@@ -1,0 +1,53 @@
+use criterion::*;
+use symagen::random_data;
+
+use distances::simd;
+
+use distances::vectors::cosine as cosine_generic;
+
+fn simd_f32(c: &mut Criterion) {
+    let mut group = c.benchmark_group("SimdF32");
+
+    let (cardinality, min_val, max_val) = (2, -10.0, 10.0);
+
+    for d in 0..=5 {
+        let dimensionality = 1_000 * 2_u32.pow(d) as usize;
+        let vecs = random_data::random_f32(cardinality, dimensionality, min_val, max_val, d as u64);
+
+        let id = BenchmarkId::new("Cosine-generic", dimensionality);
+        group.bench_with_input(id, &dimensionality, |b, _| {
+            b.iter(|| black_box(cosine_generic::<_, f32>(&vecs[0], &vecs[1])))
+        });
+
+        let id = BenchmarkId::new("Cosine-simd", dimensionality);
+        group.bench_with_input(id, &dimensionality, |b, _| {
+            b.iter(|| black_box(simd::cosine_f32(&vecs[0], &vecs[1])))
+        });
+    }
+    group.finish();
+}
+
+fn simd_f64(c: &mut Criterion) {
+    let mut group = c.benchmark_group("SimdF64");
+
+    let (cardinality, min_val, max_val) = (2, -10.0, 10.0);
+
+    for d in 0..=5 {
+        let dimensionality = 1_000 * 2_u32.pow(d) as usize;
+        let vecs = random_data::random_f64(cardinality, dimensionality, min_val, max_val, d as u64);
+
+        let id = BenchmarkId::new("Cosine-generic", dimensionality);
+        group.bench_with_input(id, &dimensionality, |b, _| {
+            b.iter(|| black_box(cosine_generic::<_, f64>(&vecs[0], &vecs[1])))
+        });
+
+        let id = BenchmarkId::new("Cosine-simd", dimensionality);
+        group.bench_with_input(id, &dimensionality, |b, _| {
+            b.iter(|| black_box(simd::cosine_f64(&vecs[0], &vecs[1])))
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(benches, simd_f32, simd_f64);
+criterion_main!(benches);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,4 +29,4 @@ pub mod strings;
 pub mod vectors;
 
 /// The version of the crate.
-pub const VERSION: &str = "1.4.1";
+pub const VERSION: &str = "1.5.0";

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,4 +29,4 @@ pub mod strings;
 pub mod vectors;
 
 /// The version of the crate.
-pub const VERSION: &str = "1.6.0-dev0";
+pub const VERSION: &str = "1.4.1";

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,4 +29,4 @@ pub mod strings;
 pub mod vectors;
 
 /// The version of the crate.
-pub const VERSION: &str = "1.4.1";
+pub const VERSION: &str = "1.6.0-dev0";

--- a/src/simd/f32x16.rs
+++ b/src/simd/f32x16.rs
@@ -17,18 +17,6 @@ impl F32x16 {
             slice[0], slice[1], slice[2], slice[3], slice[4], slice[5], slice[6], slice[7],
             slice[8], slice[9], slice[10], slice[11], slice[12], slice[13], slice[14], slice[15],
         )
-        // unsafe {
-        //     Self(
-        //         *slice.get_unchecked(0),
-        //         *slice.get_unchecked(1),
-        //         *slice.get_unchecked(2),
-        //         *slice.get_unchecked(3),
-        //         *slice.get_unchecked(4),
-        //         *slice.get_unchecked(5),
-        //         *slice.get_unchecked(6),
-        //         *slice.get_unchecked(7),
-        //     )
-        // }
     }
 
     pub fn horizontal_add(self) -> f32 {

--- a/src/simd/f32x16.rs
+++ b/src/simd/f32x16.rs
@@ -1,0 +1,62 @@
+use std::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Sub, SubAssign};
+
+define_ty!(F32x16, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32);
+impl_minimal!(
+    F32x16, f32, 16, x0, x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14, x15
+);
+
+impl F32x16 {
+    /// Create a new `F32x16` from a slice.
+    ///
+    /// # Panics
+    ///
+    /// Will panic if the slice is not at least 16 elements long.
+    pub fn from_slice(slice: &[f32]) -> Self {
+        debug_assert!(slice.len() >= Self::lanes());
+        Self(
+            slice[0], slice[1], slice[2], slice[3], slice[4], slice[5], slice[6], slice[7],
+            slice[8], slice[9], slice[10], slice[11], slice[12], slice[13], slice[14], slice[15],
+        )
+        // unsafe {
+        //     Self(
+        //         *slice.get_unchecked(0),
+        //         *slice.get_unchecked(1),
+        //         *slice.get_unchecked(2),
+        //         *slice.get_unchecked(3),
+        //         *slice.get_unchecked(4),
+        //         *slice.get_unchecked(5),
+        //         *slice.get_unchecked(6),
+        //         *slice.get_unchecked(7),
+        //     )
+        // }
+    }
+
+    pub fn horizontal_add(self) -> f32 {
+        self.0
+            + self.1
+            + self.2
+            + self.3
+            + self.4
+            + self.5
+            + self.6
+            + self.7
+            + self.8
+            + self.9
+            + self.10
+            + self.11
+            + self.12
+            + self.13
+            + self.14
+            + self.15
+    }
+}
+
+impl_op16!(Mul, mul, F32x16, *);
+impl_op16!(assn MulAssign, mul_assign, F32x16, *=);
+impl_op16!(Div, div, F32x16, /);
+impl_op16!(assn DivAssign, div_assign, F32x16, /=);
+impl_op16!(Add, add, F32x16, +);
+impl_op16!(assn AddAssign, add_assign, F32x16, +=);
+impl_op16!(Sub, sub, F32x16, -);
+impl_op16!(assn SubAssign, sub_assign, F32x16, -=);
+impl_distances!(F32x16, f32);

--- a/src/simd/f32x4.rs
+++ b/src/simd/f32x4.rs
@@ -12,14 +12,6 @@ impl F32x4 {
     pub fn from_slice(slice: &[f32]) -> Self {
         debug_assert!(slice.len() >= Self::lanes());
         Self(slice[0], slice[1], slice[2], slice[3])
-        // unsafe {
-        //     Self(
-        //         *slice.get_unchecked(0),
-        //         *slice.get_unchecked(1),
-        //         *slice.get_unchecked(2),
-        //         *slice.get_unchecked(3),
-        //     )
-        // }
     }
 
     pub fn horizontal_add(self) -> f32 {

--- a/src/simd/f32x4.rs
+++ b/src/simd/f32x4.rs
@@ -10,7 +10,7 @@ impl F32x4 {
     ///
     /// Will panic if the slice is not at least 4 elements long.
     pub fn from_slice(slice: &[f32]) -> Self {
-        assert!(slice.len() >= Self::lanes());
+        debug_assert!(slice.len() >= Self::lanes());
         Self(slice[0], slice[1], slice[2], slice[3])
         // unsafe {
         //     Self(
@@ -36,4 +36,4 @@ impl_op4!(assn AddAssign, add_assign, F32x4, +=);
 impl_op4!(Sub, sub, F32x4, -);
 impl_op4!(assn SubAssign, sub_assign, F32x4, -=);
 
-impl_euclidean!(F32x4, f32);
+impl_distances!(F32x4, f32);

--- a/src/simd/f32x8.rs
+++ b/src/simd/f32x8.rs
@@ -14,18 +14,6 @@ impl F32x8 {
         Self(
             slice[0], slice[1], slice[2], slice[3], slice[4], slice[5], slice[6], slice[7],
         )
-        // unsafe {
-        //     Self(
-        //         *slice.get_unchecked(0),
-        //         *slice.get_unchecked(1),
-        //         *slice.get_unchecked(2),
-        //         *slice.get_unchecked(3),
-        //         *slice.get_unchecked(4),
-        //         *slice.get_unchecked(5),
-        //         *slice.get_unchecked(6),
-        //         *slice.get_unchecked(7),
-        //     )
-        // }
     }
 
     pub fn horizontal_add(self) -> f32 {

--- a/src/simd/f32x8.rs
+++ b/src/simd/f32x8.rs
@@ -10,7 +10,7 @@ impl F32x8 {
     ///
     /// Will panic if the slice is not at least 8 elements long.
     pub fn from_slice(slice: &[f32]) -> Self {
-        assert!(slice.len() >= Self::lanes());
+        debug_assert!(slice.len() >= Self::lanes());
         Self(
             slice[0], slice[1], slice[2], slice[3], slice[4], slice[5], slice[6], slice[7],
         )
@@ -41,4 +41,4 @@ impl_op8!(Add, add, F32x8, +);
 impl_op8!(assn AddAssign, add_assign, F32x8, +=);
 impl_op8!(Sub, sub, F32x8, -);
 impl_op8!(assn SubAssign, sub_assign, F32x8, -=);
-impl_euclidean!(F32x8, f32);
+impl_distances!(F32x8, f32);

--- a/src/simd/f64x2.rs
+++ b/src/simd/f64x2.rs
@@ -12,7 +12,6 @@ impl F64x2 {
     pub fn from_slice(slice: &[f64]) -> Self {
         debug_assert!(slice.len() >= Self::lanes());
         Self(slice[0], slice[1])
-        // unsafe { Self(*slice.get_unchecked(0), *slice.get_unchecked(1)) }
     }
 
     pub fn horizontal_add(self) -> f64 {

--- a/src/simd/f64x2.rs
+++ b/src/simd/f64x2.rs
@@ -10,7 +10,7 @@ impl F64x2 {
     ///
     /// Will panic if the slice is not at least 2 elements long.
     pub fn from_slice(slice: &[f64]) -> Self {
-        assert!(slice.len() >= Self::lanes());
+        debug_assert!(slice.len() >= Self::lanes());
         Self(slice[0], slice[1])
         // unsafe { Self(*slice.get_unchecked(0), *slice.get_unchecked(1)) }
     }
@@ -29,4 +29,4 @@ impl_op2!(assn AddAssign, add_assign, F64x2, +=);
 impl_op2!(Sub, sub, F64x2, -);
 impl_op2!(assn SubAssign, sub_assign, F64x2, -=);
 
-impl_euclidean!(F64x2, f64);
+impl_distances!(F64x2, f64);

--- a/src/simd/f64x4.rs
+++ b/src/simd/f64x4.rs
@@ -12,14 +12,6 @@ impl F64x4 {
     pub fn from_slice(slice: &[f64]) -> Self {
         debug_assert!(slice.len() >= Self::lanes());
         Self(slice[0], slice[1], slice[2], slice[3])
-        // unsafe {
-        //     F64x4(
-        //         *slice.get_unchecked(0),
-        //         *slice.get_unchecked(1),
-        //         *slice.get_unchecked(2),
-        //         *slice.get_unchecked(3),
-        //     )
-        // }
     }
 
     pub fn horizontal_add(self) -> f64 {

--- a/src/simd/f64x4.rs
+++ b/src/simd/f64x4.rs
@@ -10,7 +10,7 @@ impl F64x4 {
     ///
     /// Will panic if the slice is not at least 4 elements long.
     pub fn from_slice(slice: &[f64]) -> Self {
-        assert!(slice.len() >= Self::lanes());
+        debug_assert!(slice.len() >= Self::lanes());
         Self(slice[0], slice[1], slice[2], slice[3])
         // unsafe {
         //     F64x4(
@@ -36,4 +36,4 @@ impl_op4!(assn AddAssign, add_assign, F64x4, +=);
 impl_op4!(Sub, sub, F64x4, -);
 impl_op4!(assn SubAssign, sub_assign, F64x4, -=);
 
-impl_euclidean!(F64x4, f64);
+impl_distances!(F64x4, f64);

--- a/src/simd/f64x8.rs
+++ b/src/simd/f64x8.rs
@@ -14,7 +14,6 @@ impl F64x8 {
         Self(
             slice[0], slice[1], slice[2], slice[3], slice[4], slice[5], slice[6], slice[7],
         )
-        // unsafe { Self(*slice.get_unchecked(0), *slice.get_unchecked(1)) }
     }
 
     pub fn horizontal_add(self) -> f64 {

--- a/src/simd/f64x8.rs
+++ b/src/simd/f64x8.rs
@@ -1,0 +1,34 @@
+use std::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Sub, SubAssign};
+
+define_ty!(F64x8, f64, f64, f64, f64, f64, f64, f64, f64);
+impl_minimal!(F64x8, f64, 8, x0, x1, x2, x3, x4, x5, x6, x7);
+
+impl F64x8 {
+    /// Create a new `F64x8` from a slice.
+    ///
+    /// # Panics
+    ///
+    /// Will panic if the slice is not at least 8 elements long.
+    pub fn from_slice(slice: &[f64]) -> Self {
+        debug_assert!(slice.len() >= Self::lanes());
+        Self(
+            slice[0], slice[1], slice[2], slice[3], slice[4], slice[5], slice[6], slice[7],
+        )
+        // unsafe { Self(*slice.get_unchecked(0), *slice.get_unchecked(1)) }
+    }
+
+    pub fn horizontal_add(self) -> f64 {
+        self.0 + self.1 + self.2 + self.3 + self.4 + self.5 + self.6 + self.7
+    }
+}
+
+impl_op8!(Mul, mul, F64x8, *);
+impl_op8!(assn MulAssign, mul_assign, F64x8, *=);
+impl_op8!(Div, div, F64x8, /);
+impl_op8!(assn DivAssign, div_assign, F64x8, /=);
+impl_op8!(Add, add, F64x8, +);
+impl_op8!(assn AddAssign, add_assign, F64x8, +=);
+impl_op8!(Sub, sub, F64x8, -);
+impl_op8!(assn SubAssign, sub_assign, F64x8, -=);
+
+impl_distances!(F64x8, f64);

--- a/src/simd/macros.rs
+++ b/src/simd/macros.rs
@@ -346,34 +346,3 @@ macro_rules! impl_naive {
         }
     };
 }
-/*
-macro_rules! impl_cosine {
-    ($name:ident, $ty:ty, $lanes:literal) => {
-        impl $name {
-            /// Calculate the dot product of two slices
-            pub fn dot(a: &[$ty], b: &[$ty]) -> $name {
-                $name::from_slice(a)
-                    .zip($name::from_slice(b))
-                    .fold($name::splat(0 as $ty), |acc, (a, b)| a.mul_add(b, acc))
-                    .reduce_sum()
-            }
-            pub fn cosine(a: &[$ty], b: &[$ty]) -> $name {
-                let xx = $name::dot(a, a);
-                let yy = $name::dot(b, b);
-                let xy = $name::dot(a, b);
-
-                if xx < $ty::epsilon() || yy < $ty::epsilon() || xy < $name::epsilon() {
-                    $name::one()
-                } else {
-                    let d = $ty::one() - xy * (xx * yy).inv_sqrt();
-                    if d < $ty::epsilon() {
-                        $ty::zero()
-                    } else {
-                        d
-                    }
-                }
-            }
-        }
-    };
-}
-*/

--- a/src/simd/mod.rs
+++ b/src/simd/mod.rs
@@ -104,6 +104,7 @@ impl Vectorized for &[f32] {
     type Output = f32;
     fn squared_euclidean(self, other: Self) -> Self::Output {
         if self.len() >= 64 {
+            // TODO will this fail on 128-bit?
             F32x8::squared_euclidean(self, other)
         } else {
             F32x4::squared_euclidean(self, other)

--- a/src/simd/mod.rs
+++ b/src/simd/mod.rs
@@ -8,53 +8,72 @@
 /// Computes the euclidean distance between two vectors.
 #[must_use]
 pub fn euclidean_f32(a: &[f32], b: &[f32]) -> f32 {
-    Vectorized::distance(a, b)
+    Vectorized::euclidean(a, b)
 }
 
 /// Computes the euclidean distance between two vectors.
 #[must_use]
 pub fn euclidean_sq_f32(a: &[f32], b: &[f32]) -> f32 {
-    Vectorized::squared_distance(a, b)
+    Vectorized::squared_euclidean(a, b)
 }
 
 /// Computes the euclidean distance between two vectors.
 #[must_use]
 pub fn euclidean_f64(a: &[f64], b: &[f64]) -> f64 {
-    Vectorized::distance(a, b)
+    Vectorized::euclidean(a, b)
 }
 
 /// Computes the euclidean distance between two vectors.
 #[must_use]
 pub fn euclidean_sq_f64(a: &[f64], b: &[f64]) -> f64 {
-    Vectorized::squared_distance(a, b)
+    Vectorized::squared_euclidean(a, b)
+}
+
+/// Computes the cosine distance between two vectors.
+#[must_use]
+pub fn cosine_f32(a: &[f32], b: &[f32]) -> f32 {
+    Vectorized::cosine(a, b)
+}
+
+/// Computes the cosine distance between two vectors.
+#[must_use]
+pub fn cosine_f64(a: &[f64], b: &[f64]) -> f64 {
+    Vectorized::cosine(a, b)
 }
 
 #[macro_use]
 mod macros;
 
+mod f32x16;
 mod f32x4;
 mod f32x8;
 
 mod f64x2;
 mod f64x4;
+mod f64x8;
 
+pub use f32x16::F32x16;
 pub use f32x4::F32x4;
 pub use f32x8::F32x8;
 pub use f64x2::F64x2;
 pub use f64x4::F64x4;
+pub use f64x8::F64x8;
 
 pub(crate) trait Naive {
     type Output;
     type Ty;
 
-    fn squared_distance(self, other: Self) -> Self::Output;
-    fn distance(self, other: Self) -> Self::Output;
+    fn squared_euclidean(self, other: Self) -> Self::Output;
+    fn euclidean(self, other: Self) -> Self::Output;
+    fn cosine(self, other: Self) -> Self::Output;
+    fn cosine_acc(self, other: Self) -> [Self::Output; 3];
 }
 
 pub(crate) trait Vectorized {
     type Output;
-    fn squared_distance(self, other: Self) -> Self::Output;
-    fn distance(self, other: Self) -> Self::Output;
+    fn squared_euclidean(self, other: Self) -> Self::Output;
+    fn euclidean(self, other: Self) -> Self::Output;
+    fn cosine(self, other: Self) -> Self::Output;
 }
 
 impl_naive!(f64, f64);
@@ -67,7 +86,7 @@ impl_naive!(f32, f32);
 /// Will panic if the lengths of the slices are not equal
 #[allow(dead_code)]
 pub(crate) fn scalar_euclidean<T: Naive>(a: T, b: T) -> T::Output {
-    Naive::distance(a, b)
+    Naive::euclidean(a, b)
 }
 
 /// SIMD-capable calculation of the euclidean distance between two slices
@@ -78,66 +97,98 @@ pub(crate) fn scalar_euclidean<T: Naive>(a: T, b: T) -> T::Output {
 /// Will panic if the lengths of the slices are not equal
 #[allow(dead_code)]
 pub(crate) fn vector_euclidean<T: Vectorized>(a: T, b: T) -> T::Output {
-    Vectorized::distance(a, b)
+    Vectorized::euclidean(a, b)
 }
 
 impl Vectorized for &[f32] {
     type Output = f32;
-    fn squared_distance(self, other: Self) -> Self::Output {
+    fn squared_euclidean(self, other: Self) -> Self::Output {
         if self.len() >= 64 {
-            F32x8::squared_distance(self, other)
+            F32x8::squared_euclidean(self, other)
         } else {
-            F32x4::squared_distance(self, other)
+            F32x4::squared_euclidean(self, other)
         }
     }
 
-    fn distance(self, other: Self) -> Self::Output {
-        Vectorized::squared_distance(self, other).sqrt()
+    fn euclidean(self, other: Self) -> Self::Output {
+        Vectorized::squared_euclidean(self, other).sqrt()
+    }
+
+    fn cosine(self, other: Self) -> Self::Output {
+        if self.len() >= 64 {
+            F32x8::cosine(self, other)
+        } else {
+            F32x4::cosine(self, other)
+        }
     }
 }
 
 impl Vectorized for &Vec<f32> {
     type Output = f32;
-    fn squared_distance(self, other: Self) -> Self::Output {
+    fn squared_euclidean(self, other: Self) -> Self::Output {
         if self.len() >= 64 {
-            F32x8::squared_distance(self, other)
+            F32x8::squared_euclidean(self, other)
         } else {
-            F32x4::squared_distance(self, other)
+            F32x4::squared_euclidean(self, other)
         }
     }
 
-    fn distance(self, other: Self) -> Self::Output {
-        Vectorized::squared_distance(self, other).sqrt()
+    fn euclidean(self, other: Self) -> Self::Output {
+        Vectorized::squared_euclidean(self, other).sqrt()
+    }
+
+    fn cosine(self, other: Self) -> Self::Output {
+        if self.len() >= 64 {
+            F32x8::cosine(self, other)
+        } else {
+            F32x4::cosine(self, other)
+        }
     }
 }
 
 impl Vectorized for &[f64] {
     type Output = f64;
-    fn squared_distance(self, other: Self) -> Self::Output {
+    fn squared_euclidean(self, other: Self) -> Self::Output {
         if self.len() >= 16 {
-            F64x4::squared_distance(self, other)
+            F64x4::squared_euclidean(self, other)
         } else {
-            F64x2::squared_distance(self, other)
+            F64x2::squared_euclidean(self, other)
         }
     }
 
-    fn distance(self, other: Self) -> Self::Output {
-        Vectorized::squared_distance(self, other).sqrt()
+    fn euclidean(self, other: Self) -> Self::Output {
+        Vectorized::squared_euclidean(self, other).sqrt()
+    }
+
+    fn cosine(self, other: Self) -> Self::Output {
+        if self.len() >= 16 {
+            F64x4::cosine(self, other)
+        } else {
+            F64x2::cosine(self, other)
+        }
     }
 }
 
 impl Vectorized for &Vec<f64> {
     type Output = f64;
-    fn squared_distance(self, other: Self) -> Self::Output {
+    fn squared_euclidean(self, other: Self) -> Self::Output {
         if self.len() >= 16 {
-            F64x4::squared_distance(self, other)
+            F64x4::squared_euclidean(self, other)
         } else {
-            F64x2::squared_distance(self, other)
+            F64x2::squared_euclidean(self, other)
         }
     }
 
-    fn distance(self, other: Self) -> Self::Output {
-        Vectorized::squared_distance(self, other).sqrt()
+    fn euclidean(self, other: Self) -> Self::Output {
+        Vectorized::squared_euclidean(self, other).sqrt()
+    }
+
+    fn cosine(self, other: Self) -> Self::Output {
+        if self.len() >= 16 {
+            F64x4::cosine(self, other)
+        } else {
+            F64x2::cosine(self, other)
+        }
     }
 }
 
@@ -167,24 +218,24 @@ mod test {
             let y = &YS[..i];
             let res = scalar_euclidean(x, y);
             assert!(
-                (Vectorized::distance(x, y) - res).abs() < 0.0001,
+                (Vectorized::euclidean(x, y) - res).abs() < 0.0001,
                 "iter {}, {} != {}",
                 i,
-                Vectorized::distance(x, y),
+                Vectorized::euclidean(x, y),
                 res
             );
             assert!(
-                (F32x8::distance(x, y) - res).abs() < 0.0001,
+                (F32x8::euclidean(x, y) - res).abs() < 0.0001,
                 "iter {}, {} != {}",
                 i,
-                F32x8::distance(x, y),
+                F32x8::euclidean(x, y),
                 res
             );
             assert!(
-                (F32x4::distance(x, y) - res).abs() < 0.0001,
+                (F32x4::euclidean(x, y) - res).abs() < 0.0001,
                 "iter {}, {} != {}",
                 i,
-                F32x4::distance(x, y),
+                F32x4::euclidean(x, y),
                 res
             );
         }
@@ -201,7 +252,7 @@ mod test {
             let (a, b) = (&data[0], &data[1]);
 
             let diff = (vector_euclidean(a, b) - scalar_euclidean(a, b)).abs();
-            assert!(diff <= 1e-4, "diff = {}, len = {}", diff, i);
+            assert!(diff <= 1e-4, "diff = {diff}, len = {i}");
         }
     }
 
@@ -210,7 +261,12 @@ mod test {
         let a = F32x4::from_slice(&[1.0, 2.0, 3.0, 4.0]);
         let b = F32x4::from_slice(&[4.0, 3.0, 2.0, 1.0]);
         let c = a * b;
-        assert_eq!(c.horizontal_add(), 4.0 + 6.0 + 6.0 + 4.0);
+        let act: f32 = 4.0 + 6.0 + 6.0 + 4.0;
+        let exp = c.horizontal_add();
+        assert!(
+            (exp - act).abs() <= f32::EPSILON,
+            "Euclidean squared: expected: {exp}, actual: {act}"
+        );
     }
 
     #[test]
@@ -218,7 +274,12 @@ mod test {
         let mut a = F32x4::from_slice(&[1.0, 2.0, 3.0, 4.0]);
         let b = F32x4::from_slice(&[4.0, 3.0, 2.0, 1.0]);
         a *= b;
-        assert_eq!(a.horizontal_add(), 4.0 + 6.0 + 6.0 + 4.0);
+        let act: f32 = 4.0 + 6.0 + 6.0 + 4.0;
+        let exp = a.horizontal_add();
+        assert!(
+            (exp - act).abs() <= f32::EPSILON,
+            "Euclidean squared: expected: {exp}, actual: {act}"
+        );
     }
 
     #[test]

--- a/tests/test_simd.rs
+++ b/tests/test_simd.rs
@@ -1,94 +1,21 @@
-// use core::f32::EPSILON;
+#![allow(unused_imports, dead_code)]
 
 use symagen::random_data;
 
-use distances::simd;
+use distances::{
+    simd,
+    vectors::{cosine, euclidean, euclidean_sq},
+    Number,
+};
 
-use distances::vectors::{cosine, euclidean, euclidean_sq};
-
-use distances::Number;
-// fn l1_f32(x: &[f32], y: &[f32]) -> f32 {
-//     x.iter()
-//         .zip(y.iter())
-//         .fold(0., |acc, (x, y)| acc + (x - y).abs())
-// }
-
-// fn l2_sq_f32(x: &[f32], y: &[f32]) -> f32 {
-//     x.iter()
-//         .zip(y.iter())
-//         .fold(0., |acc, (x, y)| acc + (x - y).powi(2))
-// }
-//
-// fn l2_f32(x: &[f32], y: &[f32]) -> f32 {
-//     l2_sq_f32(x, y).sqrt()
-// }
-//
-// // fn l1_f64(x: &[f64], y: &[f64]) -> f64 {
-// //     x.iter()
-// //         .zip(y.iter())
-// //         .fold(0., |acc, (x, y)| acc + (x - y).abs())
-// // }
-//
-// fn l2_sq_f64(x: &[f64], y: &[f64]) -> f64 {
-//     x.iter()
-//         .zip(y.iter())
-//         .fold(0., |acc, (x, y)| acc + (x - y).powi(2))
-// }
-//
-// fn l2_f64(x: &[f64], y: &[f64]) -> f64 {
-//     l2_sq_f64(x, y).sqrt()
-// }
-
-// fn cos_f32(x: &[f32], y: &[f32]) -> f32 {
-//     let [xx, yy, xy] = x
-//         .iter()
-//         .zip(y.iter())
-//         .fold([0_f32; 3], |[xx, yy, xy], (&a, &b)| {
-//             [a.mul_add(a, xx), b.mul_add(b, yy), a.mul_add(b, xy)]
-//         });
-//
-//     if xx < f32::EPSILON || yy < f32::EPSILON || xy < f32::EPSILON {
-//         1_f32
-//     } else {
-//         let d = 1_f32 - xy / (xx * yy).sqrt();
-//         if d < f32::EPSILON {
-//             0_f32
-//         } else {
-//             d
-//         }
-//     }
-// }
-//
-// fn cos_f64(x: &[f64], y: &[f64]) -> f64 {
-//     let [xx, yy, xy] = x
-//         .iter()
-//         .zip(y.iter())
-//         .fold([0_f64; 3], |[xx, yy, xy], (&a, &b)| {
-//             [a.mul_add(a, xx), b.mul_add(b, yy), a.mul_add(b, xy)]
-//         });
-//
-//     if xx < f64::EPSILON || yy < f64::EPSILON || xy < f64::EPSILON {
-//         1_f64
-//     } else {
-//         let d = 1_f64 - xy / (xx * yy).sqrt();
-//         if d < f64::EPSILON {
-//             0_f64
-//         } else {
-//             d
-//         }
-//     }
-// }
-
-fn gen_data_f32() -> Vec<Vec<f32>> {
-    let seed = 42;
-    let (cardinality, dimensionality) = (100, 10_000);
+fn gen_data_f32(seed: u64) -> Vec<Vec<f32>> {
+    let (cardinality, dimensionality) = (100, 2_usize.pow(12));
     let (min_val, max_val) = (-10., 10.);
 
     random_data::random_f32(cardinality, dimensionality, min_val, max_val, seed)
 }
 
 fn gen_data_f64(seed: u64) -> Vec<Vec<f64>> {
-    // let seed = 42;
     let (cardinality, dimensionality) = (100, 2_usize.pow(12));
     let (min_val, max_val) = (-10., 10.);
 
@@ -96,109 +23,13 @@ fn gen_data_f64(seed: u64) -> Vec<Vec<f64>> {
 }
 
 #[test]
-#[ignore]
-fn lp_squared_f32_simd() {
-    let data = gen_data_f32();
-    let mut count = 0;
-    for x in data.iter() {
-        for y in data.iter() {
-            count += 1;
-            let expected: f32 = euclidean_sq(x, y);
-            let actual: f32 = simd::euclidean_sq_f32(x, y);
-            assert!(
-                (expected - actual).abs() <= 48.0 * f32::EPSILON,
-                "SIMD Euclidean squared #{count}: expected: {}, actual: {}\nx: {:?}\ny: {:?}\ne:{}",
-                expected,
-                actual,
-                x,
-                y,
-                48.0 * f32::EPSILON
-            );
-        }
-    }
-}
-
-#[test]
-#[ignore]
-fn lp_f32_simd() {
-    let data = gen_data_f32();
-    let mut count = 0;
-    for x in data.iter() {
-        for y in data.iter() {
-            count += 1;
-
-            let expected: f32 = euclidean(x, y);
-            let actual: f32 = simd::euclidean_f32(x, y);
-            assert!(
-                (expected - actual).abs() <= 8.0 * f32::EPSILON,
-                "SIMD Euclidean: expected #{count}: {}, actual: {}\nx: {:?}\ny: {:?}",
-                expected,
-                actual,
-                x,
-                y
-            );
-        }
-    }
-}
-
-#[test]
-#[ignore]
-fn cos_f32_simd() {
-    let data = gen_data_f32();
-    let mut count = 0;
-    for x in data.iter() {
-        for y in data.iter() {
-            count += 1;
-            let expected: f32 = cosine(x, y);
-            let actual: f32 = simd::cosine_f32(x, y);
-            assert!(
-                (expected - actual).abs() <= 8.0 * f32::EPSILON,
-                "SIMD Cosine: expected #{count}: {}, actual: {}\nx: {:?}\ny: {:?}",
-                expected,
-                actual,
-                x,
-                y
-            );
-        }
-    }
-}
-
-#[test]
-#[ignore]
-fn lp_squared_f64_simd() {
-    let data = gen_data_f64(42);
-    let mut count = 0;
-    for x in data.iter() {
-        for y in data.iter() {
-            count += 1;
-            let expected: f64 = euclidean_sq(x, y);
-            let actual: f64 = simd::euclidean_sq_f64(x, y);
-            assert!(
-                (expected - actual).abs() <= 48.0 * f64::EPSILON,
-                "SIMD Euclidean squared #{count}: expected: {}, actual: {}\nx: {:?}\ny: {:?}\ne:{}",
-                expected,
-                actual,
-                x,
-                y,
-                48.0 * f64::EPSILON
-            );
-        }
-    }
-}
-
-#[test]
-
 fn lp_f64_simd() {
     let datax = gen_data_f64(42);
     let datay = gen_data_f64(65);
     let logdim = 1.0 + datax[0].len().as_f64().log2();
-    // let mut count = 0;
-    // let mut failures = 0;
     let mut failures = Vec::new();
     for (i, x) in datax.iter().enumerate() {
         for (j, y) in datay.iter().enumerate() {
-            // count += 1;
-
             let expected: f64 = euclidean(x, y);
             let actual: f64 = simd::euclidean_f64(x, y);
             let delta = (expected - actual).abs();
@@ -206,12 +37,6 @@ fn lp_f64_simd() {
             if delta > threshold {
                 failures.push((i, j, delta, threshold));
             }
-            // assert!(
-            //     (expected - actual).abs() <= 8.0 * f64::EPSILON,
-            //     "SIMD Euclidean #{count}: expected: {}, actual: {}",
-            //     expected,
-            //     actual
-            // );
         }
     }
     assert!(
@@ -220,22 +45,4 @@ fn lp_f64_simd() {
         failures.len(),
         &failures[..5]
     );
-}
-
-#[test]
-#[ignore]
-fn cos_f64_simd() {
-    let data = gen_data_f64(42);
-    let mut count = 0;
-    for x in data.iter() {
-        for y in data.iter() {
-            count += 1;
-            let expected: f64 = cosine(x, y);
-            let actual: f64 = simd::cosine_f64(x, y);
-            assert!(
-                (expected - actual).abs() <= 8.0 * f64::EPSILON,
-                "SIMD Cosine #{count}: expected: {expected}, actual: {actual}"
-            );
-        }
-    }
 }

--- a/tests/test_simd.rs
+++ b/tests/test_simd.rs
@@ -1,11 +1,9 @@
-#![allow(unused_imports, dead_code)]
-
 use symagen::random_data;
+use test_case::test_case;
 
 use distances::{
     simd,
     vectors::{cosine, euclidean, euclidean_sq},
-    Number,
 };
 
 fn gen_data_f32(seed: u64) -> Vec<Vec<f32>> {
@@ -22,26 +20,57 @@ fn gen_data_f64(seed: u64) -> Vec<Vec<f64>> {
     random_data::random_f64(cardinality, dimensionality, min_val, max_val, seed)
 }
 
-#[test]
-fn lp_f64_simd() {
-    let datax = gen_data_f64(42);
-    let datay = gen_data_f64(65);
-    let logdim = 1.0 + datax[0].len().as_f64().log2();
+#[test_case(euclidean_sq, simd::euclidean_sq_f32; "euclidean_sq_f32")]
+#[test_case(euclidean, simd::euclidean_f32; "euclidean_f32")]
+#[test_case(cosine, simd::cosine_f32; "cosine_f32")]
+fn simd_distances_f32(naive: fn(&[f32], &[f32]) -> f32, simd: fn(&[f32], &[f32]) -> f32) {
+    let data_x = gen_data_f32(42);
+    let data_y = gen_data_f32(65);
     let mut failures = Vec::new();
-    for (i, x) in datax.iter().enumerate() {
-        for (j, y) in datay.iter().enumerate() {
-            let expected: f64 = euclidean(x, y);
-            let actual: f64 = simd::euclidean_f64(x, y);
+
+    for (i, x) in data_x.iter().enumerate() {
+        for (j, y) in data_y.iter().enumerate() {
+            let expected: f32 = naive(x, y);
+            let actual: f32 = simd(x, y);
             let delta = (expected - actual).abs();
-            let threshold = 2.0 * logdim * actual * f64::EPSILON;
+            let threshold = 1e-5 * actual;
             if delta > threshold {
                 failures.push((i, j, delta, threshold));
             }
         }
     }
+
     assert!(
         failures.is_empty(),
-        "{} non-empty failures, {:?}",
+        "{} non-empty failures, {:?} ...",
+        failures.len(),
+        &failures[..5]
+    );
+}
+
+#[test_case(euclidean_sq, simd::euclidean_sq_f64; "euclidean_sq_f64")]
+#[test_case(euclidean, simd::euclidean_f64; "euclidean_f64")]
+#[test_case(cosine, simd::cosine_f64; "cosine_f64")]
+fn simd_distances_f64(naive: fn(&[f64], &[f64]) -> f64, simd: fn(&[f64], &[f64]) -> f64) {
+    let data_x = gen_data_f64(42);
+    let data_y = gen_data_f64(65);
+    let mut failures = Vec::new();
+
+    for (i, x) in data_x.iter().enumerate() {
+        for (j, y) in data_y.iter().enumerate() {
+            let expected: f64 = naive(x, y);
+            let actual: f64 = simd(x, y);
+            let delta = (expected - actual).abs();
+            let threshold = 1e-10 * actual;
+            if delta > threshold {
+                failures.push((i, j, delta, threshold));
+            }
+        }
+    }
+
+    assert!(
+        failures.is_empty(),
+        "{} non-empty failures, {:?} ...",
         failures.len(),
         &failures[..5]
     );

--- a/tests/test_simd.rs
+++ b/tests/test_simd.rs
@@ -4,102 +4,106 @@ use symagen::random_data;
 
 use distances::simd;
 
+use distances::vectors::{cosine, euclidean, euclidean_sq};
+
+use distances::Number;
 // fn l1_f32(x: &[f32], y: &[f32]) -> f32 {
 //     x.iter()
 //         .zip(y.iter())
 //         .fold(0., |acc, (x, y)| acc + (x - y).abs())
 // }
 
-fn l2_sq_f32(x: &[f32], y: &[f32]) -> f32 {
-    x.iter()
-        .zip(y.iter())
-        .fold(0., |acc, (x, y)| acc + (x - y).powi(2))
-}
-
-fn l2_f32(x: &[f32], y: &[f32]) -> f32 {
-    l2_sq_f32(x, y).sqrt()
-}
-
-// fn l1_f64(x: &[f64], y: &[f64]) -> f64 {
+// fn l2_sq_f32(x: &[f32], y: &[f32]) -> f32 {
 //     x.iter()
 //         .zip(y.iter())
-//         .fold(0., |acc, (x, y)| acc + (x - y).abs())
+//         .fold(0., |acc, (x, y)| acc + (x - y).powi(2))
+// }
+//
+// fn l2_f32(x: &[f32], y: &[f32]) -> f32 {
+//     l2_sq_f32(x, y).sqrt()
+// }
+//
+// // fn l1_f64(x: &[f64], y: &[f64]) -> f64 {
+// //     x.iter()
+// //         .zip(y.iter())
+// //         .fold(0., |acc, (x, y)| acc + (x - y).abs())
+// // }
+//
+// fn l2_sq_f64(x: &[f64], y: &[f64]) -> f64 {
+//     x.iter()
+//         .zip(y.iter())
+//         .fold(0., |acc, (x, y)| acc + (x - y).powi(2))
+// }
+//
+// fn l2_f64(x: &[f64], y: &[f64]) -> f64 {
+//     l2_sq_f64(x, y).sqrt()
 // }
 
-fn l2_sq_f64(x: &[f64], y: &[f64]) -> f64 {
-    x.iter()
-        .zip(y.iter())
-        .fold(0., |acc, (x, y)| acc + (x - y).powi(2))
-}
-
-fn l2_f64(x: &[f64], y: &[f64]) -> f64 {
-    l2_sq_f64(x, y).sqrt()
-}
-
-fn cos_f32(x: &[f32], y: &[f32]) -> f32 {
-    let [xx, yy, xy] = x
-        .iter()
-        .zip(y.iter())
-        .fold([0_f32; 3], |[xx, yy, xy], (&a, &b)| {
-            [a.mul_add(a, xx), b.mul_add(b, yy), a.mul_add(b, xy)]
-        });
-
-    if xx < f32::EPSILON || yy < f32::EPSILON || xy < f32::EPSILON {
-        1_f32
-    } else {
-        let d = 1_f32 - xy / (xx * yy).sqrt();
-        if d < f32::EPSILON {
-            0_f32
-        } else {
-            d
-        }
-    }
-}
-
-fn cos_f64(x: &[f64], y: &[f64]) -> f64 {
-    let [xx, yy, xy] = x
-        .iter()
-        .zip(y.iter())
-        .fold([0_f64; 3], |[xx, yy, xy], (&a, &b)| {
-            [a.mul_add(a, xx), b.mul_add(b, yy), a.mul_add(b, xy)]
-        });
-
-    if xx < f64::EPSILON || yy < f64::EPSILON || xy < f64::EPSILON {
-        1_f64
-    } else {
-        let d = 1_f64 - xy / (xx * yy).sqrt();
-        if d < f64::EPSILON {
-            0_f64
-        } else {
-            d
-        }
-    }
-}
+// fn cos_f32(x: &[f32], y: &[f32]) -> f32 {
+//     let [xx, yy, xy] = x
+//         .iter()
+//         .zip(y.iter())
+//         .fold([0_f32; 3], |[xx, yy, xy], (&a, &b)| {
+//             [a.mul_add(a, xx), b.mul_add(b, yy), a.mul_add(b, xy)]
+//         });
+//
+//     if xx < f32::EPSILON || yy < f32::EPSILON || xy < f32::EPSILON {
+//         1_f32
+//     } else {
+//         let d = 1_f32 - xy / (xx * yy).sqrt();
+//         if d < f32::EPSILON {
+//             0_f32
+//         } else {
+//             d
+//         }
+//     }
+// }
+//
+// fn cos_f64(x: &[f64], y: &[f64]) -> f64 {
+//     let [xx, yy, xy] = x
+//         .iter()
+//         .zip(y.iter())
+//         .fold([0_f64; 3], |[xx, yy, xy], (&a, &b)| {
+//             [a.mul_add(a, xx), b.mul_add(b, yy), a.mul_add(b, xy)]
+//         });
+//
+//     if xx < f64::EPSILON || yy < f64::EPSILON || xy < f64::EPSILON {
+//         1_f64
+//     } else {
+//         let d = 1_f64 - xy / (xx * yy).sqrt();
+//         if d < f64::EPSILON {
+//             0_f64
+//         } else {
+//             d
+//         }
+//     }
+// }
 
 fn gen_data_f32() -> Vec<Vec<f32>> {
-    let seed = 4;
+    let seed = 42;
     let (cardinality, dimensionality) = (100, 10_000);
     let (min_val, max_val) = (-10., 10.);
 
     random_data::random_f32(cardinality, dimensionality, min_val, max_val, seed)
 }
 
-fn gen_data_f64() -> Vec<Vec<f64>> {
-    let seed = 4;
-    let (cardinality, dimensionality) = (100, 10_000);
+fn gen_data_f64(seed: u64) -> Vec<Vec<f64>> {
+    // let seed = 42;
+    let (cardinality, dimensionality) = (100, 2_usize.pow(12));
     let (min_val, max_val) = (-10., 10.);
 
     random_data::random_f64(cardinality, dimensionality, min_val, max_val, seed)
 }
 
 #[test]
-fn lp_f32_simd() {
+#[ignore]
+fn lp_squared_f32_simd() {
     let data = gen_data_f32();
     let mut count = 0;
     for x in data.iter() {
         for y in data.iter() {
             count += 1;
-            let expected = l2_sq_f32(x, y);
+            let expected: f32 = euclidean_sq(x, y);
             let actual: f32 = simd::euclidean_sq_f32(x, y);
             assert!(
                 (expected - actual).abs() <= 48.0 * f32::EPSILON,
@@ -110,8 +114,20 @@ fn lp_f32_simd() {
                 y,
                 48.0 * f32::EPSILON
             );
+        }
+    }
+}
 
-            let expected = l2_f32(x, y);
+#[test]
+#[ignore]
+fn lp_f32_simd() {
+    let data = gen_data_f32();
+    let mut count = 0;
+    for x in data.iter() {
+        for y in data.iter() {
+            count += 1;
+
+            let expected: f32 = euclidean(x, y);
             let actual: f32 = simd::euclidean_f32(x, y);
             assert!(
                 (expected - actual).abs() <= 8.0 * f32::EPSILON,
@@ -126,13 +142,14 @@ fn lp_f32_simd() {
 }
 
 #[test]
+#[ignore]
 fn cos_f32_simd() {
     let data = gen_data_f32();
     let mut count = 0;
     for x in data.iter() {
         for y in data.iter() {
             count += 1;
-            let expected = cos_f32(x, y);
+            let expected: f32 = cosine(x, y);
             let actual: f32 = simd::cosine_f32(x, y);
             assert!(
                 (expected - actual).abs() <= 8.0 * f32::EPSILON,
@@ -147,13 +164,14 @@ fn cos_f32_simd() {
 }
 
 #[test]
-fn lp_f64_simd() {
-    let data = gen_data_f64();
+#[ignore]
+fn lp_squared_f64_simd() {
+    let data = gen_data_f64(42);
     let mut count = 0;
     for x in data.iter() {
         for y in data.iter() {
             count += 1;
-            let expected = l2_sq_f64(x, y);
+            let expected: f64 = euclidean_sq(x, y);
             let actual: f64 = simd::euclidean_sq_f64(x, y);
             assert!(
                 (expected - actual).abs() <= 48.0 * f64::EPSILON,
@@ -164,27 +182,55 @@ fn lp_f64_simd() {
                 y,
                 48.0 * f64::EPSILON
             );
-
-            let expected = l2_f64(x, y);
-            let actual: f64 = simd::euclidean_f64(x, y);
-            assert!(
-                (expected - actual).abs() <= 8.0 * f64::EPSILON,
-                "SIMD Euclidean #{count}: expected: {}, actual: {}",
-                expected,
-                actual
-            );
         }
     }
 }
 
 #[test]
+
+fn lp_f64_simd() {
+    let datax = gen_data_f64(42);
+    let datay = gen_data_f64(65);
+    let logdim = 1.0 + datax[0].len().as_f64().log2();
+    // let mut count = 0;
+    // let mut failures = 0;
+    let mut failures = Vec::new();
+    for (i, x) in datax.iter().enumerate() {
+        for (j, y) in datay.iter().enumerate() {
+            // count += 1;
+
+            let expected: f64 = euclidean(x, y);
+            let actual: f64 = simd::euclidean_f64(x, y);
+            let delta = (expected - actual).abs();
+            let threshold = 2.0 * logdim * actual * f64::EPSILON;
+            if delta > threshold {
+                failures.push((i, j, delta, threshold));
+            }
+            // assert!(
+            //     (expected - actual).abs() <= 8.0 * f64::EPSILON,
+            //     "SIMD Euclidean #{count}: expected: {}, actual: {}",
+            //     expected,
+            //     actual
+            // );
+        }
+    }
+    assert!(
+        failures.is_empty(),
+        "{} non-empty failures, {:?}",
+        failures.len(),
+        &failures[..5]
+    );
+}
+
+#[test]
+#[ignore]
 fn cos_f64_simd() {
-    let data = gen_data_f64();
+    let data = gen_data_f64(42);
     let mut count = 0;
     for x in data.iter() {
         for y in data.iter() {
             count += 1;
-            let expected = cos_f64(x, y);
+            let expected: f64 = cosine(x, y);
             let actual: f64 = simd::cosine_f64(x, y);
             assert!(
                 (expected - actual).abs() <= 8.0 * f64::EPSILON,

--- a/tests/test_simd.rs
+++ b/tests/test_simd.rs
@@ -1,0 +1,195 @@
+// use core::f32::EPSILON;
+
+use symagen::random_data;
+
+use distances::simd;
+
+// fn l1_f32(x: &[f32], y: &[f32]) -> f32 {
+//     x.iter()
+//         .zip(y.iter())
+//         .fold(0., |acc, (x, y)| acc + (x - y).abs())
+// }
+
+fn l2_sq_f32(x: &[f32], y: &[f32]) -> f32 {
+    x.iter()
+        .zip(y.iter())
+        .fold(0., |acc, (x, y)| acc + (x - y).powi(2))
+}
+
+fn l2_f32(x: &[f32], y: &[f32]) -> f32 {
+    l2_sq_f32(x, y).sqrt()
+}
+
+// fn l1_f64(x: &[f64], y: &[f64]) -> f64 {
+//     x.iter()
+//         .zip(y.iter())
+//         .fold(0., |acc, (x, y)| acc + (x - y).abs())
+// }
+
+fn l2_sq_f64(x: &[f64], y: &[f64]) -> f64 {
+    x.iter()
+        .zip(y.iter())
+        .fold(0., |acc, (x, y)| acc + (x - y).powi(2))
+}
+
+fn l2_f64(x: &[f64], y: &[f64]) -> f64 {
+    l2_sq_f64(x, y).sqrt()
+}
+
+fn cos_f32(x: &[f32], y: &[f32]) -> f32 {
+    let [xx, yy, xy] = x
+        .iter()
+        .zip(y.iter())
+        .fold([0_f32; 3], |[xx, yy, xy], (&a, &b)| {
+            [a.mul_add(a, xx), b.mul_add(b, yy), a.mul_add(b, xy)]
+        });
+
+    if xx < f32::EPSILON || yy < f32::EPSILON || xy < f32::EPSILON {
+        1_f32
+    } else {
+        let d = 1_f32 - xy / (xx * yy).sqrt();
+        if d < f32::EPSILON {
+            0_f32
+        } else {
+            d
+        }
+    }
+}
+
+fn cos_f64(x: &[f64], y: &[f64]) -> f64 {
+    let [xx, yy, xy] = x
+        .iter()
+        .zip(y.iter())
+        .fold([0_f64; 3], |[xx, yy, xy], (&a, &b)| {
+            [a.mul_add(a, xx), b.mul_add(b, yy), a.mul_add(b, xy)]
+        });
+
+    if xx < f64::EPSILON || yy < f64::EPSILON || xy < f64::EPSILON {
+        1_f64
+    } else {
+        let d = 1_f64 - xy / (xx * yy).sqrt();
+        if d < f64::EPSILON {
+            0_f64
+        } else {
+            d
+        }
+    }
+}
+
+fn gen_data_f32() -> Vec<Vec<f32>> {
+    let seed = 4;
+    let (cardinality, dimensionality) = (100, 10_000);
+    let (min_val, max_val) = (-10., 10.);
+
+    random_data::random_f32(cardinality, dimensionality, min_val, max_val, seed)
+}
+
+fn gen_data_f64() -> Vec<Vec<f64>> {
+    let seed = 4;
+    let (cardinality, dimensionality) = (100, 10_000);
+    let (min_val, max_val) = (-10., 10.);
+
+    random_data::random_f64(cardinality, dimensionality, min_val, max_val, seed)
+}
+
+#[test]
+fn lp_f32_simd() {
+    let data = gen_data_f32();
+    let mut count = 0;
+    for x in data.iter() {
+        for y in data.iter() {
+            count += 1;
+            let expected = l2_sq_f32(x, y);
+            let actual: f32 = simd::euclidean_sq_f32(x, y);
+            assert!(
+                (expected - actual).abs() <= 48.0 * f32::EPSILON,
+                "SIMD Euclidean squared #{count}: expected: {}, actual: {}\nx: {:?}\ny: {:?}\ne:{}",
+                expected,
+                actual,
+                x,
+                y,
+                48.0 * f32::EPSILON
+            );
+
+            let expected = l2_f32(x, y);
+            let actual: f32 = simd::euclidean_f32(x, y);
+            assert!(
+                (expected - actual).abs() <= 8.0 * f32::EPSILON,
+                "SIMD Euclidean: expected #{count}: {}, actual: {}\nx: {:?}\ny: {:?}",
+                expected,
+                actual,
+                x,
+                y
+            );
+        }
+    }
+}
+
+#[test]
+fn cos_f32_simd() {
+    let data = gen_data_f32();
+    let mut count = 0;
+    for x in data.iter() {
+        for y in data.iter() {
+            count += 1;
+            let expected = cos_f32(x, y);
+            let actual: f32 = simd::cosine_f32(x, y);
+            assert!(
+                (expected - actual).abs() <= 8.0 * f32::EPSILON,
+                "SIMD Cosine: expected #{count}: {}, actual: {}\nx: {:?}\ny: {:?}",
+                expected,
+                actual,
+                x,
+                y
+            );
+        }
+    }
+}
+
+#[test]
+fn lp_f64_simd() {
+    let data = gen_data_f64();
+    let mut count = 0;
+    for x in data.iter() {
+        for y in data.iter() {
+            count += 1;
+            let expected = l2_sq_f64(x, y);
+            let actual: f64 = simd::euclidean_sq_f64(x, y);
+            assert!(
+                (expected - actual).abs() <= 48.0 * f64::EPSILON,
+                "SIMD Euclidean squared #{count}: expected: {}, actual: {}\nx: {:?}\ny: {:?}\ne:{}",
+                expected,
+                actual,
+                x,
+                y,
+                48.0 * f64::EPSILON
+            );
+
+            let expected = l2_f64(x, y);
+            let actual: f64 = simd::euclidean_f64(x, y);
+            assert!(
+                (expected - actual).abs() <= 8.0 * f64::EPSILON,
+                "SIMD Euclidean #{count}: expected: {}, actual: {}",
+                expected,
+                actual
+            );
+        }
+    }
+}
+
+#[test]
+fn cos_f64_simd() {
+    let data = gen_data_f64();
+    let mut count = 0;
+    for x in data.iter() {
+        for y in data.iter() {
+            count += 1;
+            let expected = cos_f64(x, y);
+            let actual: f64 = simd::cosine_f64(x, y);
+            assert!(
+                (expected - actual).abs() <= 8.0 * f64::EPSILON,
+                "SIMD Cosine #{count}: expected: {expected}, actual: {actual}"
+            );
+        }
+    }
+}


### PR DESCRIPTION
Implemented SIMD-accelerated cosine distance.
Wrote tests for SIMD cosine, euclidean, euclidean-squared.
Added 512 bit SIMD (will only execute on certain Xeon or AMD processors)

Currently, euclidean-squared tests are failing with somewhat unexpectedly high floating-point imprecision. Needs further investigation. 